### PR TITLE
🐛 [fix] use logger at module level, not from LCA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.DEV8 (2022-06-27)
+
+* Use `bw2calc` logger in MultiLCA class
+
 ## 2.0.DEV7 (2022-05-22)
 
 * Add `LCA.keep_first_iteration` to make iteration simpler

--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -1,8 +1,11 @@
+import logging
 import numpy as np
 from bw2data import calculation_setups
 
 from .lca import LCA
 
+
+logger = logging.getLogger("bw2calc")
 
 class InventoryMatrices:
     def __init__(self, biosphere_matrix, supply_arrays):
@@ -38,7 +41,7 @@ class MultiLCA:
         self.func_units = cs["inv"]
         self.methods = cs["ia"]
         self.lca = LCA(demand=self.all, method=self.methods[0], log_config=log_config)
-        self.lca.logger.info(
+        logger.info(
             {
                 "message": "Started MultiLCA calculation",
                 "methods": list(self.methods),

--- a/bw2calc/version.py
+++ b/bw2calc/version.py
@@ -1,1 +1,1 @@
-version = (2, 0, "DEV7")
+version = (2, 0, "DEV8")


### PR DESCRIPTION
The logger to be used in LCA and MultiLCA is the one of bw2calc.

Commit includes version bump from DEV7, to DEV8