### PR TITLE
Issue 61

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.DEV9 (2022-07-07)
+
+* [#61 wrap_functional_unit missing from multi_lca.py](https://github.com/brightway-lca/brightway2-calc/pull/58)
+
 ## 2.0.DEV8 (2022-06-28)
 
 * [#58 use logger at module level, not from LCA](https://github.com/brightway-lca/brightway2-calc/pull/58)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 2.0.DEV9 (2022-07-07)
 
 * [#61 wrap_functional_unit missing from multi_lca.py](https://github.com/brightway-lca/brightway2-calc/pull/58)
+* MultiLCA is useable again
 
 ## 2.0.DEV8 (2022-06-28)
 

--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -62,7 +62,7 @@ class MultiLCA:
             self.method_matrices.append(self.lca.characterization_matrix)
 
         for row, func_unit in enumerate(self.func_units):
-            self.lca.redo_lci(func_unit)
+            self.lca.redo_lci({fu[0].id : fu[1] for  fu in list(func_unit.items())})
             self.supply_arrays.append(self.lca.supply_array)
 
             for col, cf_matrix in enumerate(self.method_matrices):

--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -1,7 +1,8 @@
 import logging
+from bw2data.backends.proxies import Activity
 import numpy as np
 try:
-    from bw2data import calculation_setups
+    from bw2data import calculation_setups, get_activity
 except ImportError:
     calculation_setups = None
 
@@ -62,7 +63,15 @@ class MultiLCA:
             self.method_matrices.append(self.lca.characterization_matrix)
 
         for row, func_unit in enumerate(self.func_units):
-            self.lca.redo_lci({fu[0].id : fu[1] for  fu in list(func_unit.items())})
+            fu_spec, fu_demand = list(func_unit.items())[0]
+            if isinstance(fu_spec, int):
+                fu = {fu_spec : fu_demand}
+            elif isinstance(fu_spec, Activity):
+                fu = {fu[0].id : fu[1] for  fu in list(func_unit.items())}
+            elif isinstance(fu_spec, tuple):
+                a = get_activity(fu_spec)
+                fu = {a.id : fu[1] for  fu in list(func_unit.items())}
+            self.lca.redo_lci(fu)
             self.supply_arrays.append(self.lca.supply_array)
 
             for col, cf_matrix in enumerate(self.method_matrices):

--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -6,6 +6,7 @@ except ImportError:
     calculation_setups = None
 
 from .lca import LCA
+from .utils import wrap_functional_unit
 
 
 logger = logging.getLogger("bw2calc")

--- a/bw2calc/version.py
+++ b/bw2calc/version.py
@@ -1,1 +1,1 @@
-version = (2, 0, "DEV8")
+version = (2, 0, "DEV9")


### PR DESCRIPTION
Multi LCA class was broken, because it was missing some imports (for wrap_functional_unit) and because the new way of using "LCA.redo_lci"

This PR proposes fixes for this 2 problems, and it includes:

+ changelog entry
+ version bump