### PR TITLE
Remove json-logging dependency and initialization

### DIFF
--- a/bw2calc/__init__.py
+++ b/bw2calc/__init__.py
@@ -13,10 +13,6 @@ __version__ = "2.0.DEV17"
 import platform
 import warnings
 
-import json_logging
-
-json_logging.init_non_web(enable_json=True)
-
 ARM = {"arm", "arm64", "aarch64_be", "aarch64", "armv8b", "armv8l"}
 AMD_INTEL = {"ia64", "i386", "i686", "x86_64"}
 UMFPACK_WARNING = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ requires-python = ">=3.9"
 dependencies = [
         "bw_processing",
         "fsspec",
-        "json_logging",
         "matrix_utils >=0.4.3",
         "numpy",
         "pandas",


### PR DESCRIPTION
### Problem
After updating to `2.0.dev17`, we're suddenly seeing our LCA server logs transformed into JSON. While JSON logging is not in and of itself a bad thing, I'd prefer to have control over the format of our logs, rather than have them dictated as a side-effect of importing a dependency package. Prior to https://github.com/brightway-lca/brightway2-calc/commit/9b2ce5b2cdd97ae09da894b94346a3f24d5ea121, it looks like this logging init was optional.

#### Before 
```
bw-calculator  | Started server process [8]
bw-calculator  | Waiting for application startup.
bw-calculator  | Application startup complete.
```
#### After
```
bw-calculator  | {"written_at": "2024-07-03T09:25:37.116Z", "written_ts": 1719998737116708000, "msg": "Started server process [8]", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "server", "line_no": 82}
bw-calculator  | {"written_at": "2024-07-03T09:25:37.116Z", "written_ts": 1719998737116938000, "msg": "Waiting for application startup.", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "on", "line_no": 48}
bw-calculator  | {"written_at": "2024-07-03T09:25:37.117Z", "written_ts": 1719998737117367000, "msg": "Application startup complete.", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "on", "line_no": 62}
```

I couldn't find a way to override this change via something like `json_logging.init_non_web(enable_json=False)` either before or after the `bw2calc` import, so I'm open to workaround ideas.

### Solution
Remove the dependency on `json_logging` and the initialization of JSON logging. I'd argue that log format should be a decision that the user makes rather than one determined by this package.