### PR TITLE
Force correct `self.technosphere_matrix` format for solver

### DIFF
--- a/bw2calc/lca_base.py
+++ b/bw2calc/lca_base.py
@@ -1,8 +1,8 @@
 import warnings
 from collections.abc import Iterator
 from functools import partial
-from typing import Optional, Tuple
 from scipy.sparse import csc_matrix, csr_matrix
+from typing import Optional, Tuple
 
 import matrix_utils as mu
 import numpy as np
@@ -154,7 +154,14 @@ class LCABase(Iterator):
         if hasattr(self, "solver"):
             return self.solver(demand)
         else:
-            return spsolve(self.technosphere_matrix, demand)
+            if ((PYPARDISO and isinstance(self.technosphere_matrix, csr_matrix)) or
+                    (not PYPARDISO and isinstance(self.technosphere_matrix, csc_matrix))):
+                return spsolve(self.technosphere_matrix, demand)
+            elif PYPARDISO:
+                return spsolve(self.technosphere_matrix.tocsr(), demand)
+            else:
+                return spsolve(self.technosphere_matrix.tocsc(), demand)
+
 
     def lci(self, demand: Optional[dict] = None, factorize: bool = False) -> None:
         """

--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from pathlib import Path
+from scipy.sparse import csc_matrix, csr_matrix
 from typing import Iterable, Optional, Union
 
 import bw_processing as bwp
@@ -348,6 +349,12 @@ class MultiLCA(LCABase):
 
         """
         count = len(self.dicts.activity)
+
+        if PYPARDISO and isinstance(self.technosphere_matrix, csc_matrix):
+            self.technosphere_matrix.tocsr()
+        elif not PYPARDISO and isinstance(self.technosphere_matrix, csr_matrix):
+            self.technosphere_matrix.tocsc()
+
         solutions = spsolve(
             self.technosphere_matrix, np.vstack([arr for arr in self.demand_arrays.values()]).T
         )


### PR DESCRIPTION
**What**
`self.technosphere_matrix` is now forced to `csr` when using `PYPARDISO` or otherwise forced to `csc`

**Why**
1. This forces the correct matrix format for the solver, e.g. when user is over-writing their own technosphere, the correct format is still ensured
2. For scipy users, this shouldn't change anything
3. For PyPardiso users, this should speed up calculations ~10% on repeated solves, as BW would previously force the format to `csc` and then pypardiso would force it back to `csr`

- Fix #98 

See here for further discussion: https://github.com/haasad/PyPardiso/issues/75#issuecomment-2186825609

