### PR TITLE
Explicitly set array-size in MultiLCA's lci_calculation()

### DIFF
--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -350,7 +350,7 @@ class MultiLCA(LCABase):
         count = len(self.dicts.activity)
         solutions = spsolve(
             self.technosphere_matrix, np.vstack([arr for arr in self.demand_arrays.values()]).T
-        )
+        ).reshape(count, -1)
         self.supply_arrays = {name: arr for name, arr in zip(self.demands, solutions.T)}
         # Turn 1-d array into diagonal matrix
         self.inventories = mu.SparseMatrixDict(

--- a/bw2calc/multi_lca.py
+++ b/bw2calc/multi_lca.py
@@ -348,9 +348,8 @@ class MultiLCA(LCABase):
 
         """
         count = len(self.dicts.activity)
-        solutions = spsolve(
-            self.technosphere_matrix, np.vstack([arr for arr in self.demand_arrays.values()]).T
-        ).reshape(count, -1)
+        demand_matrix = np.vstack([arr for arr in self.demand_arrays.values()]).T
+        solutions = spsolve(self.technosphere_matrix, demand_matrix).reshape(count, -1)
         self.supply_arrays = {name: arr for name, arr in zip(self.demands, solutions.T)}
         # Turn 1-d array into diagonal matrix
         self.inventories = mu.SparseMatrixDict(

--- a/tests/multi_lca.py
+++ b/tests/multi_lca.py
@@ -128,6 +128,16 @@ def test_inventory_matrix_construction(dps, config, func_units):
     assert mlca.scores[(("first", "category"), "γ")] == 8 + 3
 
 
+def test_single_demand(dps, config):
+    single_func_unit = {"γ": {100: 1}}
+    mlca = MultiLCA(demands=single_func_unit, method_config=config, data_objs=dps)
+    mlca.lci()
+    mlca.lcia()
+    
+    assert mlca.scores[(("first", "category"), "γ")] == 8 + 3
+    assert mlca.scores[(("second", "category"), "γ")] == 3 * 10
+
+
 def test_normalization(dps, func_units):
     config = {
         "impact_categories": [


### PR DESCRIPTION
# What
Explicitly set array-size in `MultiLCA`'s `lci_calculation()`.

# Why
Fixes an error described by @transfluxus in https://github.com/brightway-lca/brightway2-calc/issues/100#issuecomment-2244745800 where having a single {key: value} pair in the `demands` array results in wrong scores.