### PR TITLE
Fix missing `hasattr` in `lca_base`

### DIFF
--- a/bw2calc/lca_base.py
+++ b/bw2calc/lca_base.py
@@ -198,7 +198,7 @@ class LCABase(Iterator):
         Doesn't return anything, but creates ``self.characterized_inventory``.
 
         """
-        assert hasattr(self, "inventory") or (self, "inventories"), "Must do lci first"
+        assert hasattr(self, "inventory") or hasattr(self, "inventories"), "Must do lci first"
         if not self.dicts.biosphere:
             raise EmptyBiosphere
 


### PR DESCRIPTION
Fixes missing `hasattr` in `lca_base` causing lci assertion to always evaluate to `true`