### PR TITLE
Improve scikit-umfpack import error handling

### DIFF
--- a/bw2calc/__init__.py
+++ b/bw2calc/__init__.py
@@ -46,8 +46,10 @@ except ImportError:
             import scikits.umfpack
 
             UMFPACK = True
-        except ImportError:
+        except ModuleNotFoundError:
             warnings.warn(UMFPACK_WARNING)
+        except ImportError as e:
+            warnings.warn(f"scikit-umfpack found but couldn't be imported. Error: {e}")
     elif pltf in AMD_INTEL:
         warnings.warn(PYPARDISO_WARNING)
 


### PR DESCRIPTION
When scikit-umfpack is installed but fails to import due to compatibility issues (like the NumPy `Tester` class being removed), users receive a generic error message suggesting they install the package, even though it's already installed. This caused me to spend about 2 hours debugging why the package wasn't being detected, only to realize the issue was actually a compatibility problem with NumPy.
This PR modifies the exception handling to distinguish between:
- A missing package (`ModuleNotFoundError`) - shows the original installation prompt
- Other import errors (`ImportError`) - shows the actual error message