### PR TITLE
Add a `JacobiGMRESLCA` class to solve large technosphere matrices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw2calc` Changelog
 
+## Unreleased
+
+* Add `JacobiGMRESLCA`, an iterative `LCA` variant using Jacobi preconditioning with GMRES.
+
 ### 2.3.2 (2026-01-25)
 
 * Update `MethodConfig` for changes in 2.3.1

--- a/dev/compare_direct_vs_jacobi_gmres.ipynb
+++ b/dev/compare_direct_vs_jacobi_gmres.ipynb
@@ -1,0 +1,342 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4b57dbae",
+   "metadata": {},
+   "source": [
+    "# Compare direct solve vs Jacobi-GMRES in bw2calc\n",
+    "\n",
+    "This notebook runs the same LCA twice:\n",
+    "\n",
+    "- `LCA` (direct sparse solve)\n",
+    "- `JacobiGMRESLCA` (Jacobi-preconditioned GMRES with fallback)\n",
+    "\n",
+    "It then compares runtime and numerical agreement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a9a2efe1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from bw2calc import LCA, JacobiGMRESLCA\n",
+    "import bw2data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "346508f3-b0a9-4621-9612-28e4a557e49b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bw2data.projects.set_current(\"ecoinvent-3.10-cutoff\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6d1cc286-5e18-47c2-aa05-71972a15a271",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('CML v4.8 2016 no LT',\n",
+       " 'climate change no LT',\n",
+       " 'global warming potential (GWP100) no LT')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "method = [m for m in bw2data.methods if \"GWP100\" in str(m)][0]\n",
+    "method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3c8b3cb2-2d54-4db3-acea-d565d022c1cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db = bw2data.Database(\"ecoinvent-3.10.1-cutoff\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ca79530b-98ce-4695-96a2-085dbe578eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'passenger car production, diesel' (kilogram, GLO, None)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "act = [a for a in db if a[\"name\"].startswith(\"passenger car production, diesel\") and a[\"location\"] == \"GLO\"][0]\n",
+    "act"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ead42db-a2dd-484b-8034-41b25198fbc3",
+   "metadata": {},
+   "source": [
+    "### Attempt with regular-size database"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f545fd63-a525-41b4-b670-22663175a2e9",
+   "metadata": {},
+   "source": [
+    "The wall time used to be 4.2 seconds before using pandas.unique() in matrix_utils."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "197f5882-d5b0-45a1-9114-1e3ee351e946",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7.411258715859462\n",
+      "CPU times: user 652 ms, sys: 73.7 ms, total: 726 ms\n",
+      "Wall time: 544 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "lca = LCA({act:1}, method)\n",
+    "lca.lci()\n",
+    "lca.lcia()\n",
+    "print(lca.score)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "385bcfac-48c1-4a8a-87ce-1bc5a1192f2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7.411258715477395\n",
+      "CPU times: user 284 ms, sys: 114 ms, total: 398 ms\n",
+      "Wall time: 350 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "lca = JacobiGMRESLCA({act:1}, method)\n",
+    "lca.lci()\n",
+    "lca.lcia()\n",
+    "print(lca.score)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "004af2a2-ced6-4343-ac04-e063b30114da",
+   "metadata": {},
+   "source": [
+    "### Attempt with large-size database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "52de6db2-76a1-4a8c-ac38-8fd53e33ed39",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "251593"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db = bw2data.Database(\"ecoinvent-3.10.1-cutoff - regionalized\")\n",
+    "len(db)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "75360947-5a54-483d-b96e-70031d3f11db",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'passenger car production, diesel' (kilogram, GLO, None)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "act = [a for a in db if a[\"name\"].startswith(\"passenger car production, diesel\") and a[\"location\"] == \"GLO\"][0]\n",
+    "act"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49cbd88d-2dd8-4f90-b4f7-87ecd5381d4b",
+   "metadata": {},
+   "source": [
+    "The wall time used to be 15 minutes before using pandas.unique() in matrix_utils."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "bc8ee4ce-d859-41c9-b2bc-c643e65ef864",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6.049230549617069\n",
+      "CPU times: user 17min 58s, sys: 13min 31s, total: 31min 29s\n",
+      "Wall time: 10min 34s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/homebrew/Caskroom/miniforge/base/envs/bw2calc/lib/python3.12/site-packages/scikits/umfpack/umfpack.py:737: UmfpackWarning: (almost) singular matrix! (estimated cond. number: 1.69e+14)\n",
+      "  warnings.warn(msg, UmfpackWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "lca = LCA({act:1}, method)\n",
+    "lca.lci()\n",
+    "lca.lcia()\n",
+    "print(lca.score)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d6bec265-bdc8-4fbc-9038-266df3408c4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6.049230545497951\n",
+      "CPU times: user 3.65 s, sys: 588 ms, total: 4.24 s\n",
+      "Wall time: 4.01 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "lca = JacobiGMRESLCA({act:1}, method)\n",
+    "lca.lci()\n",
+    "lca.lcia()\n",
+    "print(lca.score)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a5c72976-0671-43d2-b442-12a629140e1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8c41f31e-a43e-4a75-a5c2-cefaa7fb2cc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float64(13.146000318)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.array([17.4357463 , 11.03358014, 17.09238729, 13.20164585, 15.03311766, 4.20133189, 15.45619411, 14.72765565, 16.20026822,  7.07807607]).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b068121-feca-414b-8411-ecfad0d90050",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/bw2calc/__init__.py
+++ b/src/bw2calc/__init__.py
@@ -2,6 +2,7 @@
 __all__ = [
     "CachingLCA",
     "DenseLCA",
+    "JacobiGMRESLCA",
     "LCA",
     "LeastSquaresLCA",
     "IterativeLCA",
@@ -69,6 +70,7 @@ from bw2calc.caching_lca import CachingLCA
 from bw2calc.dense_lca import DenseLCA
 from bw2calc.fast_scores import FastScoresOnlyMultiLCA
 from bw2calc.iterative_lca import IterativeLCA
+from bw2calc.jacobi_gmres_lca import JacobiGMRESLCA
 from bw2calc.lca import LCA
 from bw2calc.least_squares import LeastSquaresLCA
 from bw2calc.method_config import MethodConfig

--- a/src/bw2calc/jacobi_gmres_lca.py
+++ b/src/bw2calc/jacobi_gmres_lca.py
@@ -1,0 +1,134 @@
+from typing import Optional
+
+import numpy as np
+import scipy.sparse as sps
+from scipy.sparse.linalg import LinearOperator, gmres
+
+from bw2calc.lca import LCA
+
+
+class JacobiGMRESLCA(LCA):
+    """Solve ``Ax=b`` with GMRES using a Jacobi preconditioner.
+
+    The preconditioner is the inverse of the technosphere diagonal, i.e. ``D^-1``.
+    This prior decomposition can significantly improve convergence for certain types of
+    matrices, especially those with dominant diagonal entries.
+
+    :param demand: Functional unit mapping passed through to :class:`bw2calc.lca.LCA`.
+    :type demand: dict
+    :param data_objs: Datapackages passed through to :class:`bw2calc.lca.LCA`.
+    :type data_objs: iterable
+    :param rtol:
+        Relative tolerance for GMRES convergence. Convergence is checked against a threshold
+        comparable to ``max(rtol * ||b||, atol)``.
+    :type rtol: float
+    :param atol: Absolute tolerance floor for GMRES convergence.
+    :type atol: float
+    :param restart: Number of iterations between GMRES restarts. ``None`` uses SciPy defaults.
+    :type restart: int or None
+    :param maxiter: Maximum number of outer GMRES iterations.
+    :type maxiter: int or None
+    :param use_guess:
+        If ``True``, reuse the previous solution as ``x0`` for subsequent solves in the same
+        instance.
+    :type use_guess: bool
+    """
+
+    def __init__(
+        self,
+        *args,
+        rtol: float = 1e-8,
+        atol: float = 0.0,
+        restart: Optional[int] = 50,
+        maxiter: Optional[int] = 300,
+        use_guess: bool = True,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.rtol = rtol
+        self.atol = atol
+        self.restart = restart
+        self.maxiter = maxiter
+        self.use_guess = use_guess
+        self._matrix_prepared = False
+        self._cached_preconditioner: Optional[LinearOperator] = None
+        self.guess = None
+
+    def __next__(self) -> None:
+        self._matrix_prepared = False
+        self._cached_preconditioner = None
+        super().__next__()
+
+    def load_lci_data(self, nonsquare_ok=False) -> None:
+        super().load_lci_data(nonsquare_ok=nonsquare_ok)
+        self._matrix_prepared = False
+        self._cached_preconditioner = None
+        self.guess = None
+
+    def _prepare_matrix(self) -> None:
+        if self._matrix_prepared:
+            return
+        if not sps.isspmatrix(self.technosphere_matrix):
+            raise TypeError("technosphere_matrix must be a SciPy sparse matrix")
+
+        self.technosphere_matrix = self.technosphere_matrix.tocsc(copy=False)
+        self.technosphere_matrix.sum_duplicates()
+        self.technosphere_matrix.eliminate_zeros()
+        self.technosphere_matrix.sort_indices()
+        self._matrix_prepared = True
+
+    def _build_jacobi_preconditioner(self) -> Optional[LinearOperator]:
+        if self._cached_preconditioner is not None:
+            return self._cached_preconditioner
+
+        diagonal = self.technosphere_matrix.diagonal()
+        if np.any(diagonal == 0):
+            return None
+
+        inverse_diagonal = 1.0 / diagonal
+        self._cached_preconditioner = LinearOperator(
+            shape=self.technosphere_matrix.shape,
+            matvec=lambda x: inverse_diagonal * x,
+            dtype=self.technosphere_matrix.dtype,
+        )
+        return self._cached_preconditioner
+
+    def solve_linear_system(self, demand: Optional[np.ndarray] = None) -> np.ndarray:
+        if demand is None:
+            demand = self.demand_array
+
+        self._prepare_matrix()
+        preconditioner = self._build_jacobi_preconditioner()
+        x0 = self.guess if (self.use_guess and self.guess is not None) else None
+
+        try:
+            solution, _ = gmres(
+                self.technosphere_matrix,
+                demand,
+                x0=x0,
+                rtol=self.rtol,
+                atol=self.atol,
+                restart=self.restart,
+                maxiter=self.maxiter,
+                M=preconditioner,
+            )
+        except TypeError:
+            solution, _ = gmres(
+                self.technosphere_matrix,
+                demand,
+                x0=x0,
+                tol=self.rtol,
+                atol=self.atol,
+                restart=self.restart,
+                maxiter=self.maxiter,
+                M=preconditioner,
+            )
+
+        solution = np.asarray(solution)
+        if not solution.shape:
+            solution = solution.reshape((1,))
+
+        if self.use_guess:
+            self.guess = solution
+
+        return solution

--- a/tests/test_jacobi_gmres_lca.py
+++ b/tests/test_jacobi_gmres_lca.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import numpy as np
+import scipy.sparse as sps
+
+from bw2calc import LCA, JacobiGMRESLCA
+
+fixture_dir = Path(__file__).resolve().parent / "fixtures"
+
+
+def test_jacobi_gmres_lci_matches_lca_basic_fixture():
+    packages = [fixture_dir / "basic_fixture.zip"]
+
+    reference = LCA({1: 1}, data_objs=packages)
+    reference.lci()
+
+    jacobi = JacobiGMRESLCA({1: 1}, data_objs=packages)
+    jacobi.lci()
+
+    assert np.allclose(jacobi.supply_array, reference.supply_array)
+
+
+def test_jacobi_gmres_returns_no_preconditioner_for_zero_diagonal():
+    jacobi = JacobiGMRESLCA.__new__(JacobiGMRESLCA)
+    jacobi.technosphere_matrix = sps.csc_matrix([[0.0, 1.0], [1.0, 2.0]])
+    jacobi._cached_preconditioner = None
+
+    preconditioner = jacobi._build_jacobi_preconditioner()
+
+    assert preconditioner is None
+
+
+def test_jacobi_gmres_uses_previous_solution_as_guess(monkeypatch):
+    calls = []
+
+    def fake_gmres(matrix, demand, **kwargs):
+        calls.append(kwargs.get("x0"))
+        return np.array([0.2, 0.6]), 0
+
+    monkeypatch.setattr("bw2calc.jacobi_gmres_lca.gmres", fake_gmres)
+
+    jacobi = JacobiGMRESLCA.__new__(JacobiGMRESLCA)
+    jacobi.technosphere_matrix = sps.csr_matrix([[4.0, 1.0], [1.0, 3.0]])
+    jacobi.rtol = 1e-8
+    jacobi.atol = 0.0
+    jacobi.restart = 50
+    jacobi.maxiter = 300
+    jacobi.use_guess = True
+    jacobi._matrix_prepared = False
+    jacobi._cached_preconditioner = None
+    jacobi.guess = None
+
+    demand = np.array([1.0, 2.0])
+    jacobi.solve_linear_system(demand)
+    jacobi.solve_linear_system(demand)
+
+    assert calls[0] is None
+    assert np.allclose(calls[1], np.array([0.2, 0.6]))


### PR DESCRIPTION
### Issue

Solving large matrices, such as those generated by `regioinvent`, with a direct solver (PARDISO, UMFPACK), can be costly.

### Summary

This PR adds `JacobiGMRESLCA`, a new LCA variant that solves the technosphere system with Jacobi preconditioning (D^-1) + iterative solver (GMRES).

### Included

New class: `bw2calc.JacobiGMRESLCA`

Tests done:

* Score agreement with the standard solver (UMFPACK)
* [Example notebook](https://github.com/romainsacchi/brightway2-calc/blob/main/dev/compare_direct_vs_jacobi_gmres.ipynb) comparing direct LCA vs JacobiGMRESLCA

Untested for:

* Intel architectures using PARDISO

### Notes

* Intended for large sparse systems where direct solves are costly. 
* Uses the same `lci()`/`lcia()` workflow as existing LCA classes.

# Use example

````
from bw2calc import JacobiGMRESLCA

lca = JacobiGMRESLCA(
    demand={some_product_id: 1},
    rtol=1e-8,
    restart=50,
    maxiter=300,
)
lca.lci()
lca.lcia()
print(lca.score)
````