### PR TITLE
Add PartitionedMonteCarloLCA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+        "bw_graph_tools >=0.8",
         "bw_processing >=1.0",
         "fsspec",
         "matrix_utils >=0.6",

--- a/src/bw2calc/__init__.py
+++ b/src/bw2calc/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "MethodConfig",
     "MultiLCA",
     "FastScoresOnlyMultiLCA",
+    "PartitionedMonteCarloLCA",
 ]
 
 __version__ = "2.4.0"
@@ -75,3 +76,4 @@ from bw2calc.lca import LCA
 from bw2calc.least_squares import LeastSquaresLCA
 from bw2calc.method_config import MethodConfig
 from bw2calc.multi_lca import MultiLCA
+from bw2calc.partitioned_lca import PartitionedMonteCarloLCA

--- a/src/bw2calc/errors.py
+++ b/src/bw2calc/errors.py
@@ -71,3 +71,30 @@ class InconsistentLCIA(BW2CalcError):
     """Provided weighting or normalization doesn't fit the impact category"""
 
     pass
+
+
+class MissingDatabaseDependencies(BW2CalcError):
+    """A datapackage is missing the 'database_dependencies' metadata field required for
+    partitioned Monte Carlo. Reprocess the database with bw2data >= 4.7."""
+
+    pass
+
+
+class CyclicDependencyGraph(BW2CalcError):
+    """The database dependency graph contains a cycle, making partitioned Monte Carlo impossible"""
+
+    pass
+
+
+class StaticDependsOnStochastic(BW2CalcError):
+    """A database marked as static has a dependency on a database marked as stochastic.
+    Static databases must only depend on other static databases."""
+
+    pass
+
+
+class DemandInStaticDatabase(BW2CalcError):
+    """The functional unit demand points to an activity in a static database.
+    The demand must be in the stochastic (foreground) system."""
+
+    pass

--- a/src/bw2calc/partitioned_lca.py
+++ b/src/bw2calc/partitioned_lca.py
@@ -16,6 +16,43 @@ from bw2calc.lca import LCA
 from bw2calc.utils import get_datapackage
 
 
+def _find_production_exchanges(mm: mu.MappedMatrix):
+    """Run all production-exchange heuristics and return whatever was found.
+
+    Same logic as ``bw_graph_tools.guess_production_exchanges`` but does not raise
+    ``UnclearProductionExchange`` when some columns are unresolved.  This is intentional:
+    we call this on a non-square stochastic-only matrix whose unresolved rows are exactly
+    the interface products we want to identify.
+
+    Retains the other checks from ``guess_production_exchanges``: raises ``ValueError``
+    for an empty matrix or mismatched row/column result arrays.
+
+    Returns ``(row_indices, col_indices)`` — integer arrays of matrix row/column indices
+    where production exchanges were found.  Unresolved columns are simply absent.
+    """
+    from bw_graph_tools.matrix_tools import (  # noqa: PLC0415
+        gpe_fifth_heuristic,
+        gpe_first_heuristic,
+        gpe_fourth_heuristic,
+        gpe_second_heuristic,
+        gpe_third_heuristic,
+    )
+
+    if mm.matrix.shape[0] == 0:
+        raise ValueError("Empty matrix")
+
+    row, col = gpe_first_heuristic(mm)
+    row, col = gpe_second_heuristic(mm, row, col)
+    row, col = gpe_third_heuristic(mm, row, col)
+    row, col = gpe_fourth_heuristic(mm, row, col)
+    row, col = gpe_fifth_heuristic(mm, row, col)
+
+    if row.shape != col.shape:
+        raise ValueError("Guessed row indices do not match guessed column indices.")
+
+    return row, col
+
+
 class PartitionedMonteCarloLCA(Iterator):
     """Monte Carlo LCA that pre-solves a static background system once.
 
@@ -223,17 +260,9 @@ class PartitionedMonteCarloLCA(Iterator):
             return dynamic_dp
 
         # Build stochastic technosphere (deterministic) to identify interface products.
-        # We use the individual heuristics rather than guess_production_exchanges because
-        # the stochastic-only matrix is non-square (interface product rows have no
-        # corresponding column), and guess_production_exchanges raises for non-square inputs.
-        from bw_graph_tools.matrix_tools import (  # noqa: PLC0415
-            gpe_fifth_heuristic,
-            gpe_first_heuristic,
-            gpe_fourth_heuristic,
-            gpe_second_heuristic,
-            gpe_third_heuristic,
-        )
-
+        # We use _find_production_exchanges (not guess_production_exchanges) because the
+        # stochastic-only matrix is non-square — the unresolved rows are exactly the
+        # interface products we want.
         stochastic_tech_mm = mu.MappedMatrix(
             packages=self.stochastic_packages,
             matrix="technosphere_matrix",
@@ -241,19 +270,7 @@ class PartitionedMonteCarloLCA(Iterator):
             use_distributions=False,
         )
 
-        row_existing, col_existing = gpe_first_heuristic(stochastic_tech_mm)
-        row_existing, col_existing = gpe_second_heuristic(
-            stochastic_tech_mm, row_existing, col_existing
-        )
-        row_existing, col_existing = gpe_third_heuristic(
-            stochastic_tech_mm, row_existing, col_existing
-        )
-        row_existing, col_existing = gpe_fourth_heuristic(
-            stochastic_tech_mm, row_existing, col_existing
-        )
-        row_existing, col_existing = gpe_fifth_heuristic(
-            stochastic_tech_mm, row_existing, col_existing
-        )
+        row_existing, col_existing = _find_production_exchanges(stochastic_tech_mm)
 
         all_rows = np.arange(stochastic_tech_mm.matrix.shape[0])
         interface_row_indices = np.setdiff1d(all_rows, row_existing)

--- a/src/bw2calc/partitioned_lca.py
+++ b/src/bw2calc/partitioned_lca.py
@@ -82,6 +82,26 @@ class PartitionedMonteCarloLCA(Iterator):
     -----
     All LCI datapackages must contain a ``database_dependencies`` key in their metadata,
     which is written by ``bw2data >= 4.7``.
+
+    Design note: composition vs. subclassing
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    This class uses **composition**: it builds an internal ``._lca`` instance from the
+    stochastic packages plus the pre-solved dynamic datapackage, and delegates properties
+    to it.  An alternative would be to subclass ``LCA`` and override ``load_lci_data()``
+    to perform the same partitioning — classify packages, pre-solve the static system,
+    inject the dynamic datapackage, replace ``self.packages``, then call
+    ``super().load_lci_data()``.  That approach would give full inheritance of all current
+    and future ``LCA`` attributes without explicit delegation.
+
+    The reason composition was chosen instead:
+
+    * **Package list mutation.** The override would need to replace ``self.packages``
+      (set from ``data_objs`` in ``__init__``) with the filtered stochastic+dynamic list
+      mid-lifecycle, which is non-obvious and makes ``self.packages`` inconsistent with
+      ``self.data_objs``.
+    * **Matrix semantics.**  Whether composed or subclassed, ``technosphere_matrix`` is
+      the *reduced* aggregated-proxy matrix, not the full combined static+stochastic
+      system.  Subclassing makes this less visible rather than resolving it.
     """
 
     def __init__(
@@ -113,22 +133,22 @@ class PartitionedMonteCarloLCA(Iterator):
         """Pre-solve the static system, build the dynamic datapackage, and run the first LCI."""
         dynamic_dp = self._build_dynamic_datapackage()
 
-        self.lca = LCA(
+        self._lca = LCA(
             demand=self.demand,
             data_objs=self.stochastic_packages + self.method_packages + [dynamic_dp],
             use_distributions=True,
             seed_override=self.seed_override,
         )
-        self.lca.lci()
+        self._lca.lci()
 
     def lcia(self) -> None:
-        self.lca.lcia()
+        self._lca.lcia()
 
     def keep_first_iteration(self) -> None:
-        self.lca.keep_first_iteration()
+        self._lca.keep_first_iteration()
 
     def __next__(self) -> None:
-        next(self.lca)
+        next(self._lca)
 
     # ------------------------------------------------------------------
     # Delegated properties
@@ -136,35 +156,35 @@ class PartitionedMonteCarloLCA(Iterator):
 
     @property
     def score(self) -> float:
-        return self.lca.score
+        return self._lca.score
 
     @property
     def inventory(self):
-        return self.lca.inventory
+        return self._lca.inventory
 
     @property
     def supply_array(self):
-        return self.lca.supply_array
+        return self._lca.supply_array
 
     @property
     def characterized_inventory(self):
-        return self.lca.characterized_inventory
+        return self._lca.characterized_inventory
 
     @property
     def dicts(self):
-        return self.lca.dicts
+        return self._lca.dicts
 
     @property
     def technosphere_matrix(self):
-        return self.lca.technosphere_matrix
+        return self._lca.technosphere_matrix
 
     @property
     def biosphere_matrix(self):
-        return self.lca.biosphere_matrix
+        return self._lca.biosphere_matrix
 
     @property
     def characterization_matrix(self):
-        return self.lca.characterization_matrix
+        return self._lca.characterization_matrix
 
     # ------------------------------------------------------------------
     # Setup helpers

--- a/src/bw2calc/partitioned_lca.py
+++ b/src/bw2calc/partitioned_lca.py
@@ -1,0 +1,339 @@
+from collections.abc import Iterator
+from typing import Optional
+
+import bw_processing as bwp
+import matrix_utils as mu
+import numpy as np
+
+from bw2calc.errors import (
+    CyclicDependencyGraph,
+    DemandInStaticDatabase,
+    MissingDatabaseDependencies,
+    OutsideTechnosphere,
+    StaticDependsOnStochastic,
+)
+from bw2calc.lca import LCA
+from bw2calc.utils import get_datapackage
+
+
+class PartitionedMonteCarloLCA(Iterator):
+    """Monte Carlo LCA that pre-solves a static background system once.
+
+    Splits the full system into a static (background) part and a stochastic (foreground) part.
+    The static system is solved deterministically for each product demanded across the
+    static/stochastic boundary (interface products), producing aggregated biosphere vectors.
+    These are stored in an in-memory dynamic datapackage that is combined with the stochastic
+    packages for each Monte Carlo iteration.
+
+    This avoids rebuilding and solving the (typically large) background matrix on every
+    iteration — only the foreground matrix is resampled.
+
+    Parameters
+    ----------
+    demand : dict
+        Functional unit: ``{activity_or_product_id: amount}``. Must be in the stochastic system.
+    static_databases : list[str]
+        Names of databases to treat as static (e.g. ``["biosphere3", "ecoinvent 3.10"]``).
+    data_objs : list
+        All datapackages: stochastic LCI + static LCI + LCIA method. Packages for databases
+        listed in ``static_databases`` are identified by their ``metadata["name"]`` field, which
+        must equal ``bw_processing.clean_datapackage_name(database_name)``.
+    seed_override : int, optional
+        RNG seed passed to the inner stochastic LCA.
+
+    Notes
+    -----
+    All LCI datapackages must contain a ``database_dependencies`` key in their metadata,
+    which is written by ``bw2data >= 4.7``.
+    """
+
+    def __init__(
+        self,
+        demand: dict,
+        static_databases: list,
+        data_objs: list,
+        seed_override: Optional[int] = None,
+    ):
+        self.demand = demand
+        self.static_databases = list(static_databases)
+        self.seed_override = seed_override
+
+        packages = [get_datapackage(obj) for obj in data_objs]
+        (
+            self.static_packages,
+            self.stochastic_packages,
+            self.method_packages,
+        ) = self._classify_packages(packages)
+        self._validate()
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def lci(self) -> None:
+        """Pre-solve the static system, build the dynamic datapackage, and run the first LCI."""
+        dynamic_dp = self._build_dynamic_datapackage()
+
+        self.lca = LCA(
+            demand=self.demand,
+            data_objs=self.stochastic_packages + self.method_packages + [dynamic_dp],
+            use_distributions=True,
+            seed_override=self.seed_override,
+        )
+        self.lca.lci()
+
+    def lcia(self) -> None:
+        self.lca.lcia()
+
+    def keep_first_iteration(self) -> None:
+        self.lca.keep_first_iteration()
+
+    def __next__(self) -> None:
+        next(self.lca)
+
+    # ------------------------------------------------------------------
+    # Delegated properties
+    # ------------------------------------------------------------------
+
+    @property
+    def score(self) -> float:
+        return self.lca.score
+
+    @property
+    def inventory(self):
+        return self.lca.inventory
+
+    @property
+    def supply_array(self):
+        return self.lca.supply_array
+
+    @property
+    def characterized_inventory(self):
+        return self.lca.characterized_inventory
+
+    @property
+    def dicts(self):
+        return self.lca.dicts
+
+    @property
+    def technosphere_matrix(self):
+        return self.lca.technosphere_matrix
+
+    @property
+    def biosphere_matrix(self):
+        return self.lca.biosphere_matrix
+
+    @property
+    def characterization_matrix(self):
+        return self.lca.characterization_matrix
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    # ------------------------------------------------------------------
+
+    def _classify_packages(self, packages):
+        static_names = {bwp.clean_datapackage_name(db) for db in self.static_databases}
+
+        static, stochastic, method = [], [], []
+        for dp in packages:
+            matrices = {r.get("matrix") for r in dp.resources}
+            if "characterization_matrix" in matrices:
+                method.append(dp)
+            elif matrices & {"technosphere_matrix", "biosphere_matrix"}:
+                if dp.metadata.get("name", "") in static_names:
+                    static.append(dp)
+                else:
+                    stochastic.append(dp)
+
+        return static, stochastic, method
+
+    def _validate(self) -> None:
+        for dp in self.static_packages + self.stochastic_packages:
+            if "database_dependencies" not in dp.metadata:
+                raise MissingDatabaseDependencies(
+                    f"Package '{dp.metadata.get('name')}' is missing 'database_dependencies' "
+                    "metadata. Reprocess the database with bw2data >= 4.7."
+                )
+
+        stochastic_names = {dp.metadata.get("name", "") for dp in self.stochastic_packages}
+
+        for dp in self.static_packages:
+            for dep in dp.metadata.get("database_dependencies", []):
+                if bwp.clean_datapackage_name(dep) in stochastic_names:
+                    raise StaticDependsOnStochastic(
+                        f"Static database '{dp.metadata.get('name')}' depends on stochastic "
+                        f"database '{dep}'. Static databases must only depend on other static "
+                        "databases."
+                    )
+
+        graph = {
+            dp.metadata.get("name", ""): [
+                bwp.clean_datapackage_name(d) for d in dp.metadata.get("database_dependencies", [])
+            ]
+            for dp in self.static_packages + self.stochastic_packages
+        }
+        self._check_for_cycles(graph)
+
+        # Check demand is not in a static database (requires bw2data)
+        try:
+            from bw2data import get_node
+
+            static_db_set = set(self.static_databases)
+            for demand_key in self.demand:
+                try:
+                    node = get_node(id=demand_key)
+                    if node["database"] in static_db_set:
+                        raise DemandInStaticDatabase(
+                            f"Demand key {demand_key} belongs to static database "
+                            f"'{node['database']}'. The functional unit must be in the "
+                            "stochastic (foreground) system."
+                        )
+                except Exception as exc:
+                    if isinstance(exc, DemandInStaticDatabase):
+                        raise
+        except ImportError:
+            pass
+
+    @staticmethod
+    def _check_for_cycles(graph: dict) -> None:
+        visited: set = set()
+        in_stack: set = set()
+
+        def dfs(node: str) -> None:
+            visited.add(node)
+            in_stack.add(node)
+            for neighbor in graph.get(node, []):
+                if neighbor not in visited:
+                    dfs(neighbor)
+                elif neighbor in in_stack:
+                    raise CyclicDependencyGraph(
+                        f"Cycle detected in database dependency graph involving '{node}'"
+                    )
+            in_stack.discard(node)
+
+        for node in graph:
+            if node not in visited:
+                dfs(node)
+
+    def _build_dynamic_datapackage(self) -> bwp.DatapackageBase:
+        """Solve the static system for each interface product; return dynamic datapackage."""
+        dynamic_dp = bwp.create_datapackage(name="partitioned_mc_static_background")
+
+        if not self.static_packages:
+            return dynamic_dp
+
+        # Build stochastic technosphere (deterministic) to identify interface products.
+        # We use the individual heuristics rather than guess_production_exchanges because
+        # the stochastic-only matrix is non-square (interface product rows have no
+        # corresponding column), and guess_production_exchanges raises for non-square inputs.
+        from bw_graph_tools.matrix_tools import (  # noqa: PLC0415
+            gpe_fifth_heuristic,
+            gpe_first_heuristic,
+            gpe_fourth_heuristic,
+            gpe_second_heuristic,
+            gpe_third_heuristic,
+        )
+
+        stochastic_tech_mm = mu.MappedMatrix(
+            packages=self.stochastic_packages,
+            matrix="technosphere_matrix",
+            use_arrays=False,
+            use_distributions=False,
+        )
+
+        row_existing, col_existing = gpe_first_heuristic(stochastic_tech_mm)
+        row_existing, col_existing = gpe_second_heuristic(
+            stochastic_tech_mm, row_existing, col_existing
+        )
+        row_existing, col_existing = gpe_third_heuristic(
+            stochastic_tech_mm, row_existing, col_existing
+        )
+        row_existing, col_existing = gpe_fourth_heuristic(
+            stochastic_tech_mm, row_existing, col_existing
+        )
+        row_existing, col_existing = gpe_fifth_heuristic(
+            stochastic_tech_mm, row_existing, col_existing
+        )
+
+        all_rows = np.arange(stochastic_tech_mm.matrix.shape[0])
+        interface_row_indices = np.setdiff1d(all_rows, row_existing)
+
+        if not interface_row_indices.size:
+            return dynamic_dp
+
+        # Build static LCA (deterministic; dummy demand, only matrices needed)
+        from bw_graph_tools.matrix_tools import guess_production_exchanges  # noqa: PLC0415
+
+        static_lca = LCA(
+            demand={0: 1.0},
+            data_objs=self.static_packages,
+            use_distributions=False,
+        )
+        static_lca.load_lci_data()
+        static_lca.decompose_technosphere()
+
+        # Map stochastic matrix row index → product db id
+        stoch_product_reversed = {v: k for k, v in stochastic_tech_mm.row_mapper.to_dict().items()}
+
+        # Map static product db id → static activity db id (via production exchanges)
+        static_row_existing, static_col_existing = guess_production_exchanges(
+            static_lca.technosphere_mm
+        )
+        static_product_reversed = static_lca.dicts.product.reversed  # {matrix_idx: db_id}
+        static_activity_reversed = static_lca.dicts.activity.reversed  # {matrix_idx: db_id}
+
+        static_producer: dict = {}
+        for r, c in zip(static_row_existing, static_col_existing):
+            static_producer[static_product_reversed[r]] = static_activity_reversed[c]
+
+        static_biosphere_reversed = static_lca.dicts.biosphere.reversed  # {matrix_idx: db_id}
+
+        tech_rows, tech_cols, tech_data = [], [], []
+        bio_rows, bio_cols, bio_data = [], [], []
+
+        for row_idx in interface_row_indices:
+            product_id = stoch_product_reversed[row_idx]
+
+            if product_id not in static_producer:
+                raise OutsideTechnosphere(
+                    f"Interface product with id {product_id} has no identified production "
+                    "exchange in the static system. Check that all required databases are "
+                    "listed in static_databases."
+                )
+
+            proxy_activity_id = static_producer[product_id]
+
+            # Solve static system for 1 unit of this interface product
+            demand_array = np.zeros(len(static_lca.dicts.product))
+            demand_array[static_lca.dicts.product[product_id]] = 1.0
+            supply_array = static_lca.solve_linear_system(demand_array)
+
+            aggregated_bio = np.asarray(static_lca.biosphere_matrix @ supply_array).flatten()
+
+            # Production exchange: proxy_activity produces 1 unit of the interface product
+            tech_rows.append(product_id)
+            tech_cols.append(proxy_activity_id)
+            tech_data.append(1.0)
+
+            # Aggregated biosphere: all non-zero flows from the static supply chain
+            for bio_idx in np.flatnonzero(aggregated_bio):
+                bio_rows.append(static_biosphere_reversed[bio_idx])
+                bio_cols.append(proxy_activity_id)
+                bio_data.append(float(aggregated_bio[bio_idx]))
+
+        tech_indices = np.array(list(zip(tech_rows, tech_cols)), dtype=bwp.INDICES_DTYPE)
+        dynamic_dp.add_persistent_vector(
+            matrix="technosphere_matrix",
+            indices_array=tech_indices,
+            data_array=np.array(tech_data),
+        )
+
+        if bio_rows:
+            bio_indices = np.array(list(zip(bio_rows, bio_cols)), dtype=bwp.INDICES_DTYPE)
+            dynamic_dp.add_persistent_vector(
+                matrix="biosphere_matrix",
+                indices_array=bio_indices,
+                data_array=np.array(bio_data),
+            )
+
+        return dynamic_dp

--- a/src/bw2calc/partitioned_lca.py
+++ b/src/bw2calc/partitioned_lca.py
@@ -86,11 +86,13 @@ class PartitionedMonteCarloLCA(Iterator):
 
     def __init__(
         self,
-        demand: dict,
+        demand: dict[int, float],
         static_databases: list,
         data_objs: list,
         seed_override: Optional[int] = None,
     ):
+        if not all(isinstance(k, int) for k in demand):
+            raise TypeError("All demand keys must be integers (activity/product database IDs).")
         self.demand = demand
         self.static_databases = list(static_databases)
         self.seed_override = seed_override
@@ -169,18 +171,38 @@ class PartitionedMonteCarloLCA(Iterator):
     # ------------------------------------------------------------------
 
     def _classify_packages(self, packages):
+        """Classify packages into static LCI, stochastic LCI, and method buckets.
+
+        Classification happens at the resource-group level so that a single datapackage
+        containing groups for different matrices or different databases is split correctly.
+        Each resource group has a single matrix label, so we use ``dp.groups`` to iterate
+        and ``dp.exclude({"group": name})`` to produce filtered sub-packages.
+
+        Group-to-database matching uses the bw2data naming convention where a group is
+        named ``clean_datapackage_name(db_name + " " + matrix_type)`` — i.e. it starts
+        with ``clean_datapackage_name(db_name)`` followed by ``_``.  If no group-name
+        match is found, the check falls back to the package-level ``metadata["name"]``.
+        """
         static_names = {bwp.clean_datapackage_name(db) for db in self.static_databases}
 
         static, stochastic, method = [], [], []
         for dp in packages:
-            matrices = {r.get("matrix") for r in dp.resources}
-            if "characterization_matrix" in matrices:
-                method.append(dp)
-            elif matrices & {"technosphere_matrix", "biosphere_matrix"}:
-                if dp.metadata.get("name", "") in static_names:
-                    static.append(dp)
-                else:
-                    stochastic.append(dp)
+            for group_name, group_dp in dp.groups.items():
+                matrix = group_dp.resources[0].get("matrix", "")
+                filtered = dp.filter_by_attribute("group", group_name)
+
+                if matrix == "characterization_matrix":
+                    method.append(filtered)
+                elif matrix in ("technosphere_matrix", "biosphere_matrix"):
+                    # bw2data names groups as clean_datapackage_name(db + " " + matrix_type),
+                    # so a static group name starts with clean_datapackage_name(db) + "_".
+                    # Fall back to the package-level name for the one-package-per-database case.
+                    is_static = any(
+                        group_name == sn or group_name.startswith(sn + "_") for sn in static_names
+                    )
+                    if not is_static:
+                        is_static = dp.metadata.get("name", "") in static_names
+                    (static if is_static else stochastic).append(filtered)
 
         return static, stochastic, method
 
@@ -203,33 +225,14 @@ class PartitionedMonteCarloLCA(Iterator):
                         "databases."
                     )
 
-        graph = {
-            dp.metadata.get("name", ""): [
+        graph: dict[str, set] = {}
+        for dp in self.static_packages + self.stochastic_packages:
+            name = dp.metadata.get("name", "")
+            deps = {
                 bwp.clean_datapackage_name(d) for d in dp.metadata.get("database_dependencies", [])
-            ]
-            for dp in self.static_packages + self.stochastic_packages
-        }
-        self._check_for_cycles(graph)
-
-        # Check demand is not in a static database (requires bw2data)
-        try:
-            from bw2data import get_node
-
-            static_db_set = set(self.static_databases)
-            for demand_key in self.demand:
-                try:
-                    node = get_node(id=demand_key)
-                    if node["database"] in static_db_set:
-                        raise DemandInStaticDatabase(
-                            f"Demand key {demand_key} belongs to static database "
-                            f"'{node['database']}'. The functional unit must be in the "
-                            "stochastic (foreground) system."
-                        )
-                except Exception as exc:
-                    if isinstance(exc, DemandInStaticDatabase):
-                        raise
-        except ImportError:
-            pass
+            }
+            graph.setdefault(name, set()).update(deps)
+        self._check_for_cycles({k: list(v) for k, v in graph.items()})
 
     @staticmethod
     def _check_for_cycles(graph: dict) -> None:
@@ -272,6 +275,18 @@ class PartitionedMonteCarloLCA(Iterator):
 
         row_existing, col_existing = _find_production_exchanges(stochastic_tech_mm)
 
+        # Map stochastic matrix row index → product db id (used here and below)
+        stoch_product_reversed = {v: k for k, v in stochastic_tech_mm.row_mapper.to_dict().items()}
+
+        stochastic_produced_ids = {stoch_product_reversed[r] for r in row_existing}
+        for demand_key in self.demand:
+            if demand_key not in stochastic_produced_ids:
+                raise DemandInStaticDatabase(
+                    f"Demand key {demand_key} does not have a production exchange in the "
+                    "stochastic system. The functional unit must be in the stochastic "
+                    "(foreground) system, not in a static background database."
+                )
+
         all_rows = np.arange(stochastic_tech_mm.matrix.shape[0])
         interface_row_indices = np.setdiff1d(all_rows, row_existing)
 
@@ -288,9 +303,6 @@ class PartitionedMonteCarloLCA(Iterator):
         )
         static_lca.load_lci_data()
         static_lca.decompose_technosphere()
-
-        # Map stochastic matrix row index → product db id
-        stoch_product_reversed = {v: k for k, v in stochastic_tech_mm.row_mapper.to_dict().items()}
 
         # Map static product db id → static activity db id (via production exchanges)
         static_row_existing, static_col_existing = guess_production_exchanges(

--- a/tests/test_partitioned_lca.py
+++ b/tests/test_partitioned_lca.py
@@ -24,6 +24,7 @@ import pytest
 from bw2calc import PartitionedMonteCarloLCA
 from bw2calc.errors import (
     CyclicDependencyGraph,
+    DemandInStaticDatabase,
     MissingDatabaseDependencies,
     StaticDependsOnStochastic,
 )
@@ -319,11 +320,12 @@ def test_package_classification():
         data_objs=[static_dp, stochastic_dp, method_dp],
     )
 
-    assert len(p_lca.static_packages) == 1
-    assert len(p_lca.stochastic_packages) == 1
+    # Each package has tech + bio groups, so 2 filtered packages per LCI package
+    assert len(p_lca.static_packages) == 2
+    assert len(p_lca.stochastic_packages) == 2
     assert len(p_lca.method_packages) == 1
-    assert p_lca.static_packages[0].metadata["name"] == "static_db"
-    assert p_lca.stochastic_packages[0].metadata["name"] == "stochastic_db"
+    assert all(dp.metadata["name"] == "static_db" for dp in p_lca.static_packages)
+    assert all(dp.metadata["name"] == "stochastic_db" for dp in p_lca.stochastic_packages)
 
 
 def test_multiple_static_databases():
@@ -347,13 +349,44 @@ def test_multiple_static_databases():
         static_databases=["static_db", "extra_static"],
         data_objs=[static_dp1, static_dp2, stochastic_dp, method_dp],
     )
-    assert len(p_lca.static_packages) == 2
-    assert len(p_lca.stochastic_packages) == 1
+    # static_db: 2 groups (tech + bio); extra_static: 1 group (tech only)
+    assert len(p_lca.static_packages) == 3
+    assert len(p_lca.stochastic_packages) == 2
 
 
 # ---------------------------------------------------------------------------
 # Validation errors
 # ---------------------------------------------------------------------------
+
+
+def test_non_integer_demand_key_raises():
+    """Raises TypeError when demand keys are not integers."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    with pytest.raises(TypeError, match="integers"):
+        PartitionedMonteCarloLCA(
+            demand={"P3": 1.0},
+            static_databases=["static_db"],
+            data_objs=[static_dp, stochastic_dp, method_dp],
+        )
+
+
+def test_demand_in_static_database_raises():
+    """Raises DemandInStaticDatabase when the demand key is an activity in the static system."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    # Activity 100 is in the static db, not the stochastic one
+    p_lca = PartitionedMonteCarloLCA(
+        demand={100: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    with pytest.raises(DemandInStaticDatabase):
+        p_lca.lci()
 
 
 def test_missing_database_dependencies_raises():
@@ -444,3 +477,138 @@ def test_no_interface_products_returns_empty_dp():
     p_lca.lcia()
 
     assert np.isclose(p_lca.score, 0.5 * 2.0, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Mixed-matrix datapackage tests
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_lci_and_characterization_in_one_package():
+    """A single datapackage containing both static LCI groups and a characterization group."""
+    # Combine static tech + bio + characterization into one datapackage
+    combined_dp = bwp.create_datapackage(name="static_and_method")
+
+    combined_dp.add_persistent_vector(
+        matrix="technosphere_matrix",
+        name=bwp.clean_datapackage_name("static_db technosphere_matrix"),
+        indices_array=np.array([(1, 100), (2, 200), (1, 200)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, 1.0, 0.5]),
+        flip_array=np.array([False, False, True]),
+    )
+    combined_dp.add_persistent_vector(
+        matrix="biosphere_matrix",
+        name=bwp.clean_datapackage_name("static_db biosphere_matrix"),
+        indices_array=np.array([(1000, 100), (2000, 200)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([2.0, 1.0]),
+    )
+    combined_dp.add_persistent_vector(
+        matrix="characterization_matrix",
+        name="method_group",
+        indices_array=np.array([(1000, 1000), (2000, 2000)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([2.0, 1.0]),
+    )
+    combined_dp.metadata["database_dependencies"] = []
+
+    stochastic_dp = _make_stochastic_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[combined_dp, stochastic_dp],
+    )
+    assert len(p_lca.static_packages) == 2  # tech + bio groups
+    assert len(p_lca.stochastic_packages) == 2  # stochastic tech + bio groups
+    assert len(p_lca.method_packages) == 1
+
+    p_lca.lci()
+    p_lca.lcia()
+    assert np.isclose(p_lca.score, 3.2, rtol=1e-6)
+
+
+def test_static_and_stochastic_groups_in_one_package():
+    """A single datapackage containing both a static and a stochastic technosphere group."""
+    combined_dp = bwp.create_datapackage(name="combined")
+
+    combined_dp.add_persistent_vector(
+        matrix="technosphere_matrix",
+        name=bwp.clean_datapackage_name("static_db technosphere_matrix"),
+        indices_array=np.array([(1, 100), (2, 200), (1, 200)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, 1.0, 0.5]),
+        flip_array=np.array([False, False, True]),
+    )
+    combined_dp.add_persistent_vector(
+        matrix="biosphere_matrix",
+        name=bwp.clean_datapackage_name("static_db biosphere_matrix"),
+        indices_array=np.array([(1000, 100), (2000, 200)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([2.0, 1.0]),
+    )
+    combined_dp.add_persistent_vector(
+        matrix="technosphere_matrix",
+        name=bwp.clean_datapackage_name("stochastic_db technosphere_matrix"),
+        indices_array=np.array([(3, 300), (2, 300)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, 1.0]),
+        flip_array=np.array([False, True]),
+    )
+    combined_dp.add_persistent_vector(
+        matrix="biosphere_matrix",
+        name=bwp.clean_datapackage_name("stochastic_db biosphere_matrix"),
+        indices_array=np.array([(1000, 300)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([0.1]),
+    )
+    combined_dp.metadata["database_dependencies"] = []
+
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[combined_dp, method_dp],
+    )
+    assert len(p_lca.static_packages) == 2  # static tech + bio
+    assert len(p_lca.stochastic_packages) == 2  # stochastic tech + bio
+    assert len(p_lca.method_packages) == 1
+
+    p_lca.lci()
+    p_lca.lcia()
+    assert np.isclose(p_lca.score, 3.2, rtol=1e-6)
+
+
+def test_stochastic_characterization_varies():
+    """Stochastic characterization factors produce varying scores across MC iterations."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+
+    # Method with uniform distribution on CF for F1: range [1.0, 3.0], nominal 2.0
+    method_dp = bwp.create_datapackage(name="stochastic_method")
+    char_indices = np.array([(1000, 1000), (2000, 2000)], dtype=bwp.INDICES_DTYPE)
+    char_data = np.array([2.0, 1.0])
+    char_dists = np.array(
+        [
+            (4, 2.0, 0.0, np.nan, 1.0, 3.0, False),  # uniform [1.0, 3.0] for F1
+            (0, 1.0, 0.0, np.nan, np.nan, np.nan, False),  # deterministic for F2
+        ],
+        dtype=bwp.UNCERTAINTY_DTYPE,
+    )
+    method_dp.add_persistent_vector(
+        matrix="characterization_matrix",
+        indices_array=char_indices,
+        data_array=char_data,
+        distributions_array=char_dists,
+    )
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+        seed_override=99,
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    scores = [p_lca.score]
+    for _ in range(20):
+        next(p_lca)
+        scores.append(p_lca.score)
+
+    assert len(set(np.round(scores, 8))) > 1, "Scores must vary when CFs have distributions"

--- a/tests/test_partitioned_lca.py
+++ b/tests/test_partitioned_lca.py
@@ -1,0 +1,446 @@
+"""Tests for PartitionedMonteCarloLCA.
+
+System under test
+-----------------
+Static database (name "static_db"):
+    S1 (id=100): produces P1 (id=1), emits F1 (id=1000) amount=2.0
+    S2 (id=200): produces P2 (id=2), consumes P1 (id=1) amount=0.5,
+                 emits F2 (id=2000) amount=1.0
+
+Stochastic database (name "stochastic_db"):
+    A1 (id=300): produces P3 (id=3), consumes P2 (id=2) amount=1.0,
+                 emits F1 (id=1000) amount=0.1
+
+LCIA method:
+    F1 (id=1000): CF=2.0,  F2 (id=2000): CF=1.0
+
+Expected score for {P3: 1}: 1.1*2.0 + 1.0*1.0 = 3.2
+"""
+
+import bw_processing as bwp
+import numpy as np
+import pytest
+
+from bw2calc import PartitionedMonteCarloLCA
+from bw2calc.errors import (
+    CyclicDependencyGraph,
+    MissingDatabaseDependencies,
+    StaticDependsOnStochastic,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_static_dp(database_dependencies=None):
+    """Static package: S1 (100) → P1 (1), S2 (200) → P2 (2)."""
+    dp = bwp.create_datapackage(name="static_db")
+
+    tech_indices = np.array([(1, 100), (2, 200), (1, 200)], dtype=bwp.INDICES_DTYPE)
+    tech_data = np.array([1.0, 1.0, 0.5])
+    tech_flip = np.array([False, False, True])  # last is consumption P1 by S2
+
+    dp.add_persistent_vector(
+        matrix="technosphere_matrix",
+        indices_array=tech_indices,
+        data_array=tech_data,
+        flip_array=tech_flip,
+    )
+
+    bio_indices = np.array([(1000, 100), (2000, 200)], dtype=bwp.INDICES_DTYPE)
+    bio_data = np.array([2.0, 1.0])
+
+    dp.add_persistent_vector(
+        matrix="biosphere_matrix",
+        indices_array=bio_indices,
+        data_array=bio_data,
+    )
+
+    dp.metadata["database_dependencies"] = (
+        database_dependencies if database_dependencies is not None else []
+    )
+    return dp
+
+
+def _make_stochastic_dp(
+    p2_amount=1.0, f1_amount=0.1, with_distributions=False, database_dependencies=None
+):
+    """Stochastic package: A1 (300) → P3 (3), consumes P2 (2)."""
+    dp = bwp.create_datapackage(name="stochastic_db")
+
+    tech_indices = np.array([(3, 300), (2, 300)], dtype=bwp.INDICES_DTYPE)
+    tech_data = np.array([1.0, p2_amount])
+    tech_flip = np.array([False, True])
+
+    if with_distributions:
+        tech_dists = np.array(
+            [
+                (0, 1.0, 0.0, np.nan, np.nan, np.nan, False),
+                (4, p2_amount, 0.0, np.nan, p2_amount * 0.5, p2_amount * 1.5, False),
+            ],
+            dtype=bwp.UNCERTAINTY_DTYPE,
+        )
+        dp.add_persistent_vector(
+            matrix="technosphere_matrix",
+            indices_array=tech_indices,
+            data_array=tech_data,
+            flip_array=tech_flip,
+            distributions_array=tech_dists,
+        )
+    else:
+        dp.add_persistent_vector(
+            matrix="technosphere_matrix",
+            indices_array=tech_indices,
+            data_array=tech_data,
+            flip_array=tech_flip,
+        )
+
+    bio_indices = np.array([(1000, 300)], dtype=bwp.INDICES_DTYPE)
+    bio_data = np.array([f1_amount])
+
+    if with_distributions:
+        bio_dists = np.array(
+            [(4, f1_amount, 0.0, np.nan, f1_amount * 0.5, f1_amount * 2.0, False)],
+            dtype=bwp.UNCERTAINTY_DTYPE,
+        )
+        dp.add_persistent_vector(
+            matrix="biosphere_matrix",
+            indices_array=bio_indices,
+            data_array=bio_data,
+            distributions_array=bio_dists,
+        )
+    else:
+        dp.add_persistent_vector(
+            matrix="biosphere_matrix",
+            indices_array=bio_indices,
+            data_array=bio_data,
+        )
+
+    dp.metadata["database_dependencies"] = (
+        database_dependencies if database_dependencies is not None else ["static_db"]
+    )
+    return dp
+
+
+def _make_method_dp():
+    """Characterization factors: F1=2.0, F2=1.0."""
+    dp = bwp.create_datapackage(name="method")
+
+    char_indices = np.array([(1000, 1000), (2000, 2000)], dtype=bwp.INDICES_DTYPE)
+    char_data = np.array([2.0, 1.0])
+
+    dp.add_persistent_vector(
+        matrix="characterization_matrix",
+        indices_array=char_indices,
+        data_array=char_data,
+    )
+    return dp
+
+
+# ---------------------------------------------------------------------------
+# Core functionality
+# ---------------------------------------------------------------------------
+
+
+def test_first_score_matches_reference():
+    """Partitioned LCA must give the same score as a direct (non-partitioned) LCA."""
+    from bw2calc import LCA
+
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    # Reference: full system in one LCA
+    ref_lca = LCA(
+        demand={3: 1.0},
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    ref_lca.lci()
+    ref_lca.lcia()
+    expected = ref_lca.score
+
+    # Partitioned LCA
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    assert np.isclose(p_lca.score, expected, rtol=1e-6)
+    assert np.isclose(p_lca.score, 3.2, rtol=1e-6)
+
+
+def test_score_value():
+    """Verify the expected analytical score of 3.2."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    assert np.isclose(p_lca.score, 3.2, rtol=1e-6)
+
+
+def test_iteration_without_distributions():
+    """Iteration without distributions gives same score each time."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    p_lca.lci()
+    p_lca.lcia()
+    first_score = p_lca.score
+
+    for _ in range(5):
+        next(p_lca)
+        assert np.isclose(p_lca.score, first_score, rtol=1e-6)
+
+
+def test_iteration_with_distributions_varies():
+    """Iteration with stochastic distributions produces varying scores."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp(with_distributions=True)
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+        seed_override=42,
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    scores = [p_lca.score]
+    for _ in range(20):
+        next(p_lca)
+        scores.append(p_lca.score)
+
+    # Scores should vary (uniform distribution on consumption amount)
+    assert len(set(np.round(scores, 8))) > 1, "Scores should vary across MC iterations"
+
+
+def test_keep_first_iteration():
+    """keep_first_iteration uses first sample as iteration 0."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp(with_distributions=True)
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+        seed_override=1,
+    )
+    p_lca.lci()
+    p_lca.lcia()
+    first_score = p_lca.score
+
+    p_lca.keep_first_iteration()
+    next(p_lca)
+    kept_score = p_lca.score
+
+    assert np.isclose(first_score, kept_score, rtol=1e-6)
+
+
+def test_properties_accessible():
+    """inventory, supply_array, dicts, and matrix properties are accessible."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    assert p_lca.supply_array is not None
+    assert p_lca.inventory is not None
+    assert p_lca.characterized_inventory is not None
+    assert p_lca.dicts is not None
+    assert p_lca.technosphere_matrix is not None
+    assert p_lca.biosphere_matrix is not None
+    assert p_lca.characterization_matrix is not None
+
+
+def test_iterable():
+    """PartitionedMonteCarloLCA is iterable via for loop."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    scores = []
+    for _ in range(3):
+        next(p_lca)
+        scores.append(p_lca.score)
+
+    assert len(scores) == 3
+
+
+# ---------------------------------------------------------------------------
+# Package classification
+# ---------------------------------------------------------------------------
+
+
+def test_package_classification():
+    """Packages are correctly classified as static, stochastic, or method."""
+    static_dp = _make_static_dp()
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db"],
+        data_objs=[static_dp, stochastic_dp, method_dp],
+    )
+
+    assert len(p_lca.static_packages) == 1
+    assert len(p_lca.stochastic_packages) == 1
+    assert len(p_lca.method_packages) == 1
+    assert p_lca.static_packages[0].metadata["name"] == "static_db"
+    assert p_lca.stochastic_packages[0].metadata["name"] == "stochastic_db"
+
+
+def test_multiple_static_databases():
+    """Two static packages both end up in static_packages."""
+    static_dp1 = _make_static_dp()
+    static_dp2 = bwp.create_datapackage(name="extra_static")
+
+    # Minimal valid static package
+    static_dp2.add_persistent_vector(
+        matrix="technosphere_matrix",
+        indices_array=np.array([(99, 999)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+    )
+    static_dp2.metadata["database_dependencies"] = []
+
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=["static_db", "extra_static"],
+        data_objs=[static_dp1, static_dp2, stochastic_dp, method_dp],
+    )
+    assert len(p_lca.static_packages) == 2
+    assert len(p_lca.stochastic_packages) == 1
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_database_dependencies_raises():
+    """Raises MissingDatabaseDependencies when metadata field is absent."""
+    static_dp = _make_static_dp()
+    # Remove the field we just added
+    del static_dp.metadata["database_dependencies"]
+
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    with pytest.raises(MissingDatabaseDependencies):
+        PartitionedMonteCarloLCA(
+            demand={3: 1.0},
+            static_databases=["static_db"],
+            data_objs=[static_dp, stochastic_dp, method_dp],
+        )
+
+
+def test_static_depends_on_stochastic_raises():
+    """Raises StaticDependsOnStochastic when static db lists stochastic as dependency."""
+    # static_db "depends on" stochastic_db — invalid
+    static_dp = _make_static_dp(database_dependencies=["stochastic_db"])
+    stochastic_dp = _make_stochastic_dp()
+    method_dp = _make_method_dp()
+
+    with pytest.raises(StaticDependsOnStochastic):
+        PartitionedMonteCarloLCA(
+            demand={3: 1.0},
+            static_databases=["static_db"],
+            data_objs=[static_dp, stochastic_dp, method_dp],
+        )
+
+
+def test_cyclic_dependency_raises():
+    """Raises CyclicDependencyGraph when two static databases depend on each other."""
+    dp_a = bwp.create_datapackage(name="db_a")
+    dp_a.add_persistent_vector(
+        matrix="technosphere_matrix",
+        indices_array=np.array([(1, 10)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+    )
+    dp_a.metadata["database_dependencies"] = ["db_b"]
+
+    dp_b = bwp.create_datapackage(name="db_b")
+    dp_b.add_persistent_vector(
+        matrix="technosphere_matrix",
+        indices_array=np.array([(2, 20)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+    )
+    dp_b.metadata["database_dependencies"] = ["db_a"]
+
+    stochastic_dp = _make_stochastic_dp(database_dependencies=[])
+    method_dp = _make_method_dp()
+
+    with pytest.raises(CyclicDependencyGraph):
+        PartitionedMonteCarloLCA(
+            demand={3: 1.0},
+            static_databases=["db_a", "db_b"],  # both static so cycle is detected
+            data_objs=[dp_a, dp_b, stochastic_dp, method_dp],
+        )
+
+
+def test_no_interface_products_returns_empty_dp():
+    """When stochastic system is self-contained, dynamic dp is empty but LCA works."""
+    # A self-contained stochastic system (no interface products)
+    dp = bwp.create_datapackage(name="self_contained")
+    dp.add_persistent_vector(
+        matrix="technosphere_matrix",
+        indices_array=np.array([(3, 300)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+    )
+    dp.add_persistent_vector(
+        matrix="biosphere_matrix",
+        indices_array=np.array([(1000, 300)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([0.5]),
+    )
+    dp.metadata["database_dependencies"] = []
+
+    method_dp = _make_method_dp()
+
+    p_lca = PartitionedMonteCarloLCA(
+        demand={3: 1.0},
+        static_databases=[],  # no static databases
+        data_objs=[dp, method_dp],
+    )
+    p_lca.lci()
+    p_lca.lcia()
+
+    assert np.isclose(p_lca.score, 0.5 * 2.0, rtol=1e-6)


### PR DESCRIPTION
## Summary

- New `PartitionedMonteCarloLCA` class that pre-solves a static (background) database system once, then only resamples the stochastic (foreground) system each Monte Carlo iteration — avoiding repeated factorization of the large background matrix
- New `_find_production_exchanges` module-level helper: same logic as `bw_graph_tools.guess_production_exchanges` (including empty-matrix and shape-consistency guards) but returns a partial assignment rather than raising `UnclearProductionExchange`, since the stochastic-only matrix is intentionally non-square
- Four new error classes: `MissingDatabaseDependencies`, `CyclicDependencyGraph`, `StaticDependsOnStochastic`, `DemandInStaticDatabase`

## How it works

On `lci()`, the class:
1. Builds the stochastic-only technosphere and identifies **interface products** — rows with no production exchange in the stochastic system (consumed from the static background)
2. Solves the static LCA once per interface product using a factorized solver, producing an aggregated biosphere vector per product
3. Stores those vectors in an in-memory `bw_processing` datapackage keyed by the real static activity IDs
4. Creates a single inner `LCA` with `stochastic_packages + [dynamic_datapackage] + method_packages` and `use_distributions=True`

Subsequent `next()` calls resample only the stochastic matrices; the dynamic datapackage is deterministic and unchanged each iteration.

## Dependencies

- `bw2data >= 4.7` — adds `database_dependencies` to datapackage metadata (used for dependency-graph validation)
- `bw_graph_tools >= 0.8` — five production-exchange heuristics

## Test plan

- [ ] `test_first_score_matches_reference` — partitioned score equals direct full-system LCA
- [ ] `test_score_value` — analytical value (3.2) verified against hand-calculated result
- [ ] `test_iteration_without_distributions` — repeated `next()` gives identical scores when no distributions present
- [ ] `test_iteration_with_distributions_varies` — scores vary across iterations when stochastic distributions are active
- [ ] `test_keep_first_iteration` — `keep_first_iteration()` reuses sample 0 correctly
- [ ] `test_properties_accessible` — `score`, `inventory`, `supply_array`, `dicts`, matrix properties all delegate correctly
- [ ] `test_package_classification` — static/stochastic/method packages separated by `metadata["name"]`
- [ ] `test_multiple_static_databases` — two static packages both land in `static_packages`
- [ ] `test_missing_database_dependencies_raises` — `MissingDatabaseDependencies` when metadata field absent
- [ ] `test_static_depends_on_stochastic_raises` — `StaticDependsOnStochastic` when static db lists stochastic as dependency
- [ ] `test_cyclic_dependency_raises` — `CyclicDependencyGraph` for mutual dependency between two static dbs
- [ ] `test_no_interface_products_returns_empty_dp` — self-contained stochastic system works without static packages
- [ ] `test_iterable` — class is iterable via `for` / `next()`