### PR TITLE
Fix CI not running on subsequent PR commits

### DIFF
--- a/.github/workflows/python-test-pardiso.yml
+++ b/.github/workflows/python-test-pardiso.yml
@@ -17,7 +17,7 @@ on:
       - ".gitignore"
   pull_request:
     branches: [main, develop]
-    types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
       - "**.bib"

--- a/.github/workflows/python-test-superlu.yml
+++ b/.github/workflows/python-test-superlu.yml
@@ -17,7 +17,7 @@ on:
       - ".gitignore"
   pull_request:
     branches: [main, develop]
-    types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
       - "**.bib"

--- a/.github/workflows/python-test-umfpack-macos.yml
+++ b/.github/workflows/python-test-umfpack-macos.yml
@@ -17,7 +17,7 @@ on:
       - ".gitignore"
   pull_request:
     branches: [main, develop]
-    types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
       - "**.bib"


### PR DESCRIPTION
## Summary

All three test workflows (`python-test-superlu.yml`, `python-test-pardiso.yml`, `python-test-umfpack-macos.yml`) listed only `opened` and `reopened` as `pull_request` event types. The `synchronize` type — which fires when new commits are pushed to a PR branch — was intentionally excluded with the comment "excludes synchronize to avoid redundant trigger from commits on PRs".

This means CI never runs on follow-up commits to a PR, only on the initial open. Add `synchronize` to all three workflows so every push to a PR branch is tested.

## Test plan

- [ ] Open a PR and verify CI runs
- [ ] Push a follow-up commit to that PR and verify CI runs again