### PR TITLE
Fix file handle leak in switch_method/switch_normalization/switch_weighting

### DIFF
--- a/src/bw2calc/lca.py
+++ b/src/bw2calc/lca.py
@@ -364,7 +364,11 @@ class LCA(LCABase):
             setattr(self, label, obj)
         else:
             data_objs = list(obj)
-        self.packages = [pkg.exclude({"matrix": matrix}) for pkg in self.packages] + data_objs
+        # Drop packages that become empty after exclusion (e.g. a method-only zip package
+        # after switch_method) so their filesystems are released and file handles closed.
+        self.packages = [
+            p for pkg in self.packages if (p := pkg.exclude({"matrix": matrix})).resources
+        ] + data_objs
         func(data_objs=data_objs)
 
         logger.info(

--- a/tests/test_lca.py
+++ b/tests/test_lca.py
@@ -908,6 +908,55 @@ def test_switch_method():
     assert not any(res["matrix"] == "characterization_matrix" for res in lca.packages[0].resources)
 
 
+def test_switch_method_does_not_accumulate_empty_packages():
+    """Repeated switch_method calls must not accumulate empty filtered packages.
+
+    When the method lives in its own datapackage, excluding the characterization matrix
+    leaves an empty FilteredDatapackage.  Without the fix, each switch adds one of these
+    empty packages to self.packages, keeping the old method's filesystem (and any open
+    file handles) alive indefinitely.
+    """
+    lci_dp = bwp.create_datapackage()
+    lci_dp.add_persistent_vector(
+        matrix="technosphere_matrix",
+        data_array=np.array([1, 1, 0.5]),
+        indices_array=np.array([(1, 101), (2, 102), (2, 101)], dtype=bwp.INDICES_DTYPE),
+        flip_array=np.array([0, 0, 1], dtype=bool),
+    )
+    lci_dp.add_persistent_vector(
+        matrix="biosphere_matrix",
+        data_array=np.array([1.0]),
+        indices_array=np.array([(1, 101)], dtype=bwp.INDICES_DTYPE),
+    )
+
+    def _method_dp(cf_value):
+        dp = bwp.create_datapackage()
+        dp.add_persistent_vector(
+            matrix="characterization_matrix",
+            data_array=np.array([float(cf_value)]),
+            indices_array=np.array([(1, 0)], dtype=bwp.INDICES_DTYPE),
+            global_index=0,
+        )
+        return dp
+
+    method1 = _method_dp(1.0)
+    method2 = _method_dp(2.0)
+    method3 = _method_dp(3.0)
+
+    lca = LCA({1: 1}, data_objs=[lci_dp, method1])
+    lca.lci()
+    lca.lcia()
+    assert len(lca.packages) == 2
+
+    lca.switch_method([method2])
+    # method1's package becomes empty after exclude — must be dropped
+    assert len(lca.packages) == 2
+
+    lca.switch_method([method3])
+    # must still be 2, not growing with each switch
+    assert len(lca.packages) == 2
+
+
 # switch_normalization
 
 


### PR DESCRIPTION
## Summary

- `_switch` was appending empty `FilteredDatapackage` objects to `self.packages` after each call to `switch_method`, `switch_normalization`, or `switch_weighting`
- When a method lives in its own datapackage (the common case with separate zip files), excluding the characterization matrix leaves a `FilteredDatapackage` with no resources — but `bw_processing.exclude()` still copies `fs = self.fs`, keeping the old package's filesystem (e.g. an open `ZipFileSystem`) alive
- Each switch accumulated one more empty package, so file handles were never released
- Fix: drop filtered packages with no remaining resources before appending to `self.packages`

Closes #115.

## Test plan

- [ ] `test_switch_method` still passes (existing test — covers combined LCI+method package, count assertions unchanged)
- [ ] `test_switch_method_does_not_accumulate_empty_packages` — new test with a separate method package; asserts `len(lca.packages)` stays at 2 across repeated `switch_method` calls