### PR TITLE
2.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # `bw2calc` Changelog
 
+## 2.5.0 (2026-05-16)
+
+* [#148](https://github.com/brightway-lca/brightway2-calc/pull/148): Add `PartitionedMonteCarloLCA`, a Monte Carlo LCA class that pre-solves a static background system once and only resamples the stochastic foreground on each iteration
+* [#150](https://github.com/brightway-lca/brightway2-calc/pull/150): Fix file handle leak in `switch_method`, `switch_normalization`, and `switch_weighting` — empty `FilteredDatapackage` objects were accumulating in `self.packages`, keeping old method filesystems (e.g. open zip files) alive across repeated calls
+
 ### 2.4.0 (2026-02-27)
 
 * [#145](https://github.com/brightway-lca/brightway2-calc/pull/145): Add a `JacobiGMRESLCA` class to solve large technosphere matrices. Thanks @romainsacchi

--- a/src/bw2calc/__init__.py
+++ b/src/bw2calc/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     "PartitionedMonteCarloLCA",
 ]
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 
 import platform


### PR DESCRIPTION
## Summary

- Add `PartitionedMonteCarloLCA` ([#148](https://github.com/brightway-lca/brightway2-calc/pull/148)): Monte Carlo LCA that pre-solves a static background system once and only resamples the stochastic foreground on each iteration
- Fix file handle leak in `switch_method` / `switch_normalization` / `switch_weighting` ([#150](https://github.com/brightway-lca/brightway2-calc/pull/150)): empty `FilteredDatapackage` objects were accumulating in `self.packages`, keeping old method filesystems alive across repeated calls
- Bump version to 2.5.0 and update changelog

## Test plan

- [ ] CI passes on all platforms
- [ ] Version is `2.5.0`
- [ ] Changelog entry is present and accurate